### PR TITLE
Configuration for Travis CI/CD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+---
+language: ruby
+env:
+  - JEKYLL_ENV=production 
+before_install:
+  - sudo apt-get install python-pip -y
+  - sudo pip install docutils pygments
+before_script:
+   - git clone https://github.com/gryf/jekyll-rst _plugins/jekyll-rst
+install:
+  - bundle install
+script: bundle exec jekyll build

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,12 @@ before_script:
 install:
   - bundle install
 script: bundle exec jekyll build
+deploy:
+  provider: pages
+  github_token: $GITHUB_TOKEN
+  skip_cleanup: true
+  local_dir: _site
+  target_branch: gh-pages
+  on:
+    branch: master
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source "https://rubygems.org"
 ruby RUBY_VERSION
 
-# We'll need rake to build our site in TravisCI
-gem "rake", "~> 12"
 gem "jekyll"
 gem "RbST"
 gem "nokogiri"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+ruby RUBY_VERSION
+
+# We'll need rake to build our site in TravisCI
+gem "rake", "~> 12"
+gem "jekyll"
+gem "RbST"
+gem "nokogiri"


### PR DESCRIPTION
Here is the configuration for Travis CI/CD, which will build and deploy.

Here are the assumptions:

- deployment will be done on `gh-pages` branch
- build will be done by simply call `jekyll build` command in `production` environent
- jekyll-rst plugin will be cloned from `gryf/jekyll-rst`