### PR TITLE
correct casing in navigation links

### DIFF
--- a/WINGs_tutorial/WINGstep1.html
+++ b/WINGs_tutorial/WINGstep1.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-<table align="JUSTIFY" width="100%"><tbody><tr><td align="LEFT"><a href="WINGsIntro.html">LAST: Introduction</a></td>  <td align="CENTER"><a href="WINGtoc.html">Contents</a></td><td align="RIGHT"><a href="WINGStep2.html">NEXT: Step 2 Processing Events</a></td></tr></tbody></table>
+<table align="JUSTIFY" width="100%"><tbody><tr><td align="LEFT"><a href="WINGsIntro.html">LAST: Introduction</a></td>  <td align="CENTER"><a href="WINGtoc.html">Contents</a></td><td align="RIGHT"><a href="WINGstep2.html">NEXT: Step 2 Processing Events</a></td></tr></tbody></table>
 
 <h4>Step 1: Six lines show a window on the screen</h4>
 <p>

--- a/WINGs_tutorial/WINGstep2.html
+++ b/WINGs_tutorial/WINGstep2.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-<table align="JUSTIFY" width="100%"><tbody><tr><td align="LEFT"><a href="WINGStep1.html">LAST: Step 1 Drawing a Window</a></td><td align="CENTER"><a href="WINGtoc.html">Contents</a></td><td align="RIGHT"><a href="WINGStep3.html">NEXT: Step 3 Adding Widgets</a></td></tr></tbody></table>
+<table align="JUSTIFY" width="100%"><tbody><tr><td align="LEFT"><a href="WINGstep1.html">LAST: Step 1 Drawing a Window</a></td><td align="CENTER"><a href="WINGtoc.html">Contents</a></td><td align="RIGHT"><a href="WINGstep3.html">NEXT: Step 3 Adding Widgets</a></td></tr></tbody></table>
 
 <h4>Step 2: Processing events</h4>
 

--- a/WINGs_tutorial/WINGstep3.html
+++ b/WINGs_tutorial/WINGstep3.html
@@ -8,7 +8,7 @@
 </head>
 
 <body>
-<table align="JUSTIFY" width="100%"><tbody><tr><td align="LEFT"><a href="WINGStep2.html">LAST: Step 2 Processing Events</a></td><td align="CENTER"><a href="WINGtoc.html">Contents</a></td><td align="RIGHT"><a href="WINGsRemark.html">NEXT: Programming Details</a></td></tr></tbody></table>
+<table align="JUSTIFY" width="100%"><tbody><tr><td align="LEFT"><a href="WINGstep2.html">LAST: Step 2 Processing Events</a></td><td align="CENTER"><a href="WINGtoc.html">Contents</a></td><td align="RIGHT"><a href="WINGsRemark.html">NEXT: Programming Details</a></td></tr></tbody></table>
 
 <h4>Step 3: Adding widgets to a window</h4>
 


### PR DESCRIPTION
correct casing in navigation links from WINGStep2.html to WINGstep2.html, as the former gave a 404 error