### PR TITLE
Introduced submodule for Jekyll plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.jekyll-cache
+Gemfile.lock
 _site
 *~

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "_plugins/jekyll-rst"]
+	path = _plugins/jekyll-rst
+	url = https://github.com/gryf/jekyll-rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - sudo apt-get install python-pip -y
   - sudo pip install docutils pygments
 before_script:
-   - git clone https://github.com/gryf/jekyll-rst _plugins/jekyll-rst
+   - git submodule update --init
 install:
   - bundle install
 script: bundle exec jekyll build
@@ -18,5 +18,3 @@ deploy:
   target_branch: master
   on:
     branch: source
-
-

--- a/README.md
+++ b/README.md
@@ -13,16 +13,23 @@ to achieve it, is to install it from system repositories.
 
 If your distribution doesn't contain it (even in external ones, like PPA for
 Ubuntu, AUR for Arch or some portage overlay from Gentoo), that it might be
-installed locally using [Bundler](https://github.com/bundler/bundler), which
-typical usage would be as follows:
+installed locally using [Bundler](https://github.com/bundler/bundler).
+
+Manual installation would be as follows:
 
 ```
-$ cd window-maker.github.io && bundler init
-$ bundler add jekyll
-$ mkdir _plugins
-$ git clone https://github.com/gryf/jekyll-rst _plugins/jekyll-rst
+$ git clone --recurse-submodules https://github.com/window-maker/window-maker.github.io
+$ cd window-maker.github.io
+$ bundler install
+$ # install docutils and pygments from your distribution repository, or use
+$ # following command to install them from PyPI for the current user:
 $ pip install docutils pygments
-$ gem install RbST nokogiri
+```
+
+To build and serve webpage in development mode, you just issue the following
+command:
+
+```
 $ bundler exec jekyll serve
 ```
 


### PR DESCRIPTION
Currently, we need to clone restructuredText renderer manually. There
was also some brainsplit between readme file and the reality. It should
be easier now, by using either --recurse-submodules for git clone or
git submodule update --update.